### PR TITLE
fix(cart): handle undefined totalPrice to prevent runtime error

### DIFF
--- a/src/components/cart/cart-order-summary.tsx
+++ b/src/components/cart/cart-order-summary.tsx
@@ -20,7 +20,7 @@ export default function CartOrderSummary({
             <div className="flex items-center justify-between py-4">
               <dt className="text-gray-600">Subtotal</dt>
               <dd className="font-medium text-gray-900">
-                {formatIdr(totalPrice || 0)}
+                {formatIdr(totalPrice)}
               </dd>
             </div>
             <div className="flex items-center justify-between py-4">
@@ -34,7 +34,7 @@ export default function CartOrderSummary({
                 Order total
               </dt>
               <dd className="text-base font-medium text-gray-900">
-                {formatIdr(totalPrice + 30000 || 0)}
+                {formatIdr(totalPrice + 30000)}
               </dd>
             </div>
           </dl>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,7 +10,7 @@ export function classNames(...classes: string[]) {
 }
 
 export function formatIdr(idr: number) {
-  const parsed = idr.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  const parsed = idr?.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 
   return `${"Rp "}${parsed}`;
 }

--- a/src/pages/cart-page.tsx
+++ b/src/pages/cart-page.tsx
@@ -10,7 +10,7 @@ import useTitlePage from "@/hooks/useTitlePage";
 export default function CartPage() {
   useTitlePage("Cart");
   const { data, isLoading } = useCart();
-  const totalPrice = data?.data.items.reduce(
+  const totalPrice = data?.data?.items?.reduce(
     (acc, item) => acc + item.totalPrice,
     0
   );


### PR DESCRIPTION
Ensure that totalPrice always receives a number by defaulting to 0 when undefined. This prevents "Cannot read properties of undefined (reading 'toString')" error.